### PR TITLE
Force validator.js helpers to use strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.3.1(Feb 18, 2016)
+- Coerce input to string when using validator.js helpers
+
 ### 0.3.0(Feb 13, 2016)
 - Optional validations support
 

--- a/lib/validations.js
+++ b/lib/validations.js
@@ -23,7 +23,7 @@ function checkParam(paramName, message, validator) {
     return {
       field: paramName,
       message: "\""+ paramName +"\" " + message,
-      result: validator.apply(null, [param].concat(extraArgs))
+      result: validator.apply(null, [param + ""].concat(extraArgs))
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "property-validator",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Easy property validation for JavaScript, Node and Express.",
   "main": "index.js",
   "homepage": "http://github.com/nettofarah/property-validator",


### PR DESCRIPTION
This is done due to the nature of validator.js basically just applying a
set of regular expressions to any input that is sent its way.

closes #3