### PR TITLE
node 0.10.x support when running tests

### DIFF
--- a/test/request_assertions_test.js
+++ b/test/request_assertions_test.js
@@ -47,7 +47,7 @@ describe('Assertions', function() {
 
         var expectedError = {
           field: 'email_address',
-          message: `"email_address" should look like an email address`
+          message: '"email_address" should look like an email address'
         }
 
         assert.equal(1, validationError.errors.length);
@@ -61,7 +61,7 @@ describe('Assertions', function() {
           email('email_address')
         ]);
       } catch(validationError) {
-        var message = `"email_address" should look like an email address`;
+        var message = '"email_address" should look like an email address';
 
         assert.deepEqual([message], validationError.messages);
       }


### PR DESCRIPTION
while preparing a PR for #9 i've noticed that running `npm test` is broken in node v0.10 due the use of template literals.