### PR TITLE
isPlainObject/isArray validation, falsy values for presence validation, node 0.10.x support when running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Here's a list of currently supported helpers:
 |equals(paramName, comparison)| check if the string matches the comparison. |
 |isAlpha(paramName)| check if the string contains only letters (a-zA-Z). |
 |isAlphanumeric(paramName)| check if the string contains only letters and numbers. |
+|isArray(paramName)| check if the current param is an array. |
 |isCreditCard(paramName)| check if the string is a credit card. |
 |isCurrency(paramName, options)| check if the string is a valid currency amount. `options` is an object which defaults to `{symbol: '$', require_symbol: false, allow_space_after_symbol: false, symbol_after_digits: false, allow_negatives: true, parens_for_negatives: false, negative_sign_before_digits: false, negative_sign_after_digits: false, allow_negative_sign_placeholder: false, thousands_separator: ',', decimal_separator: '.', allow_space_after_digits: false }`. |
 |isDate(paramName)| check if the string is a date. |
@@ -297,6 +298,7 @@ Here's a list of currently supported helpers:
 |isURL(paramName [, options])| check if the string is an URL. `options` is an object which defaults to `{ protocols: ['http','https','ftp'], require_tld: true, require_protocol: false, require_valid_protocol: true, allow_underscores: false, host_whitelist: false, host_blacklist: false, allow_trailing_dot: false, allow_protocol_relative_urls: false }`. |
 |isUUID(paramName [, version])| check if the string is a UUID (version 3, 4 or 5). |
 |matches(paramName, pattern [, modifiers])| check if string matches the pattern. Either `matches('foo', /foo/i)` or `matches('foo', 'foo', 'i')`. |
+|isPlainObject| check if the current param is a plain object. |
 
 ### Not currently supported
 These are a few other helpers avaliable in [validator.js](https://github.com/chriso/validator.js) that could be used in property-validator.

--- a/lib/validations.js
+++ b/lib/validations.js
@@ -1,6 +1,7 @@
 var get = require('lodash/get');
 var isString = require('lodash/isString');
-var isPlainObject = require('lodash/isPlainObject');
+var isArrayValidator = require('lodash/isArray');
+var isPlainObjectValidator = require('lodash/isPlainObject');
 var includes = require('lodash/includes');
 var validator = require('validator');
 
@@ -16,7 +17,7 @@ validations.presence = function presence(paramName, customMessage) {
     return {
       field: paramName,
       message: customMessage || message(paramName, "required"),
-      result: !!get(params, paramName)
+      result: get(params, paramName) != null
     }
   }
 }
@@ -89,13 +90,13 @@ validations.isAlphanumeric = function isAlphanumeric(paramName, customMessage) {
   );
 }
 
-validations.isArray = function isPlainObject(paramName, customMessage) {
+validations.isArray = function isArray(paramName, customMessage) {
   return function(params) {
 
     return {
       field: paramName,
-      message: customMessage || message(paramName, "must be an array"),
-      result: Array.isArray(get(params, paramName))
+      message: customMessage || message(paramName, 'should be an array'),
+      result: isArrayValidator(get(params, paramName))
     }
   }
 }
@@ -220,13 +221,13 @@ validations.isURL = function isURL(paramName, options, customMessage) {
   );
 }
 
-validations.isPlainObject = function isPlainObjectValidator(paramName, customMessage) {
+validations.isPlainObject = function isPlainObject(paramName, customMessage) {
   return function(params) {
 
     return {
       field: paramName,
-      message: customMessage || message(paramName, "must be a plain object"),
-      result: isPlainObject(get(params, paramName))
+      message: customMessage || message(paramName, 'should be a plain object'),
+      result: isPlainObjectValidator(get(params, paramName))
     }
   }
 }

--- a/lib/validations.js
+++ b/lib/validations.js
@@ -1,5 +1,6 @@
 var get = require('lodash/get');
 var isString = require('lodash/isString');
+var isPlainObject = require('lodash/isPlainObject');
 var includes = require('lodash/includes');
 var validator = require('validator');
 
@@ -86,6 +87,17 @@ validations.isAlphanumeric = function isAlphanumeric(paramName, customMessage) {
     customMessage || message(paramName, 'should be alphanumeric'),
     validator.isAlphanumeric
   );
+}
+
+validations.isArray = function isPlainObject(paramName, customMessage) {
+  return function(params) {
+
+    return {
+      field: paramName,
+      message: customMessage || message(paramName, "must be an array"),
+      result: Array.isArray(get(params, paramName))
+    }
+  }
 }
 
 validations.isCreditCard = function isCreditCard(paramName, customMessage) {
@@ -206,6 +218,17 @@ validations.isURL = function isURL(paramName, options, customMessage) {
     validator.isURL,
     options
   );
+}
+
+validations.isPlainObject = function isPlainObjectValidator(paramName, customMessage) {
+  return function(params) {
+
+    return {
+      field: paramName,
+      message: customMessage || message(paramName, "must be a plain object"),
+      result: isPlainObject(get(params, paramName))
+    }
+  }
 }
 
 // TODO: Implement these validators

--- a/test/request_assertions_test.js
+++ b/test/request_assertions_test.js
@@ -47,7 +47,7 @@ describe('Assertions', function() {
 
         var expectedError = {
           field: 'email_address',
-          message: `"email_address" should look like an email address`
+          message: '"email_address" should look like an email address'
         }
 
         assert.equal(1, validationError.errors.length);
@@ -61,7 +61,7 @@ describe('Assertions', function() {
           email('email_address')
         ]);
       } catch(validationError) {
-        var message = `"email_address" should look like an email address`;
+        var message = '"email_address" should look like an email address';
 
         assert.deepEqual([message], validationError.messages);
       }

--- a/test/validation_test.js
+++ b/test/validation_test.js
@@ -252,6 +252,13 @@ describe('Validation Helpers', function() {
     f(v.isAlphanumeric('i')({ i: '#@' }));
   });
 
+  it('isArray', function() {
+    t(v.isArray('i')({ i: [1, 2, 3] }));
+    f(v.isArray('i')({ i: 'bla' }));
+
+    m(v.isArray('i')({ i: 'test' }), '"i" must be an array');
+  });
+
   it('isCreditCard', function() {
     t(v.isCreditCard('i')({ i: '375556917985515' }));
     f(v.isCreditCard('i')({ i: '123123' }));
@@ -282,5 +289,11 @@ describe('Validation Helpers', function() {
     t(v.uuid('i')({ i: 'A987FBC9-4BED-4078-8F07-9141BA07C9F3' }));
     f(v.uuid('i')({ i: 'xxxA987FBC9-4BED-3078-CF07-9141BA07C9F3' }));
     f(v.uuid('i')({ i: 'bla' }));
+  });
+
+  it('isPlainObject', function() {
+    t(v.isPlainObject('i')({ i: { foo: true } }));
+    f(v.isPlainObject('i')({ i: 'bla' }));
+    m(v.isPlainObject('i')({ i: 'test' }), '"i" must be a plain object');
   });
 });

--- a/test/validation_test.js
+++ b/test/validation_test.js
@@ -63,6 +63,47 @@ describe('Validation', function() {
     });
   });
 
+  describe('presence validation', function() {
+    var params;
+    var presence = validator.presence;
+
+    before(function() {
+      params = {}
+    });
+
+    it('allows falsy values that are not null or undefined', function() {
+      params = {
+        foo: 0,
+        bar: false,
+        baz: ''
+      };
+
+      var validation = validate(params, [
+        presence('foo'),
+        presence('bar'),
+        presence('baz')
+      ]);
+
+      assert(validation.valid);
+      assert(validation.errors.length == 0);
+    });
+
+    it('fails when fields are null or undefined', function() {
+      params = {
+        foo: null,
+        bar: undefined
+      };
+
+      var validation = validate(params, [
+        presence('foo'),
+        presence('bar')
+      ]);
+
+      assert(!validation.valid);
+      assert(validation.errors.length == 2);
+    });
+  });
+
   describe('optional validation', function() {
     var params;
     var optional = validator.optional;
@@ -256,7 +297,7 @@ describe('Validation Helpers', function() {
     t(v.isArray('i')({ i: [1, 2, 3] }));
     f(v.isArray('i')({ i: 'bla' }));
 
-    m(v.isArray('i')({ i: 'test' }), '"i" must be an array');
+    m(v.isArray('i')({ i: 'test' }), '"i" should be an array');
   });
 
   it('isCreditCard', function() {
@@ -294,6 +335,6 @@ describe('Validation Helpers', function() {
   it('isPlainObject', function() {
     t(v.isPlainObject('i')({ i: { foo: true } }));
     f(v.isPlainObject('i')({ i: 'bla' }));
-    m(v.isPlainObject('i')({ i: 'test' }), '"i" must be a plain object');
+    m(v.isPlainObject('i')({ i: 'test' }), '"i" should be a plain object');
   });
 });


### PR DESCRIPTION
while preparing a PR for #9 i've noticed that running npm test is broken in node v0.10 due the use of template literals.