### PR TITLE
Fixed a bug in the typescript type of the ValidateResult object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,10 +8,10 @@ declare module 'property-validator' {
     //result of a validation/assertion
     export type ValidateResult = {
         valid: boolean;
-        errors: {
+        errors: Array<{
             field: string;
             message: string;
-        };
+        }>;
         messages: string[]
     };
 


### PR DESCRIPTION
Stupid little mistake in the ValidateResult object. the errors property is supposed to be an array.

Hope we can push this asap :smile: 