### PR TITLE
index.d.ts: add void return type to setLocals

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ declare module 'property-validator' {
   }
 
   //function to change the locals, keeps a fallback to en locals
-  export function setLocals(locals: {})
+  export function setLocals(locals: {}): void
 
   //request validators
   export function validate(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "property-validator",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Easy property validation for JavaScript, Node and Express.",
   "main": "index.js",
   "types": "./index.d.ts",


### PR DESCRIPTION
With `noImplicitAny: true`, the TS compiler complains about `setLocals` having an implicit any return type.

I just added `void` as the return type here.